### PR TITLE
Updated the initialisation of the states to adapt to the new core

### DIFF
--- a/it.polito.elite.dog.drivers.zwave.meteringpoweroutlet/src/it/polito/elite/dog/drivers/zwave/meteringpoweroutlet/ZWaveMeteringPowerOutletInstance.java
+++ b/it.polito.elite.dog.drivers.zwave.meteringpoweroutlet/src/it/polito/elite/dog/drivers/zwave/meteringpoweroutlet/ZWaveMeteringPowerOutletInstance.java
@@ -32,6 +32,7 @@ import it.polito.elite.dog.core.library.model.statevalue.ActiveEnergyStateValue;
 import it.polito.elite.dog.core.library.model.statevalue.ActivePowerStateValue;
 import it.polito.elite.dog.core.library.model.statevalue.OffStateValue;
 import it.polito.elite.dog.core.library.model.statevalue.OnStateValue;
+import it.polito.elite.dog.core.library.model.statevalue.StateValue;
 import it.polito.elite.dog.core.library.util.LogHelper;
 import it.polito.elite.dog.drivers.zwave.ZWaveAPI;
 import it.polito.elite.dog.drivers.zwave.model.zway.json.CommandClasses;
@@ -113,7 +114,7 @@ public class ZWaveMeteringPowerOutletInstance extends ZWaveDriverInstance
 				+ SI.KILO(SI.WATT.times(NonSI.HOUR)).toString()));
 		this.currentState.setState(
 				SinglePhaseActiveEnergyState.class.getSimpleName(),
-				new SinglePhaseActiveEnergyState(energyStateValue));
+				new SinglePhaseActiveEnergyState(new StateValue[]{energyStateValue}));
 
 		// initialize the power state value
 		ActivePowerStateValue powerStateValue = new ActivePowerStateValue();
@@ -121,7 +122,7 @@ public class ZWaveMeteringPowerOutletInstance extends ZWaveDriverInstance
 				+ SI.WATT.toString()));
 		this.currentState.setState(
 				SinglePhaseActivePowerMeasurementState.class.getSimpleName(),
-				new SinglePhaseActivePowerMeasurementState(powerStateValue));
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{powerStateValue}));
 
 		// get the initial state of the device
 		Runnable worker = new Runnable()
@@ -310,7 +311,7 @@ public class ZWaveMeteringPowerOutletInstance extends ZWaveDriverInstance
 		pValue.setValue(value);
 		currentState.setState(
 				SinglePhaseActiveEnergyState.class.getSimpleName(),
-				new SinglePhaseActiveEnergyState(pValue));
+				new SinglePhaseActiveEnergyState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()
@@ -339,7 +340,7 @@ public class ZWaveMeteringPowerOutletInstance extends ZWaveDriverInstance
 		pValue.setValue(powerValue);
 		currentState.setState(
 				SinglePhaseActivePowerMeasurementState.class.getSimpleName(),
-				new SinglePhaseActivePowerMeasurementState(pValue));
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()

--- a/it.polito.elite.dog.drivers.zwave.powermeteringlevelcontrollableoutput/src/it/polito/elite/dog/drivers/zwave/powermeteringlevelcontrollableoutput/ZWavePowerMeteringLevelControllableOutputDriverInstance.java
+++ b/it.polito.elite.dog.drivers.zwave.powermeteringlevelcontrollableoutput/src/it/polito/elite/dog/drivers/zwave/powermeteringlevelcontrollableoutput/ZWavePowerMeteringLevelControllableOutputDriverInstance.java
@@ -33,6 +33,7 @@ import it.polito.elite.dog.core.library.model.statevalue.ActivePowerStateValue;
 import it.polito.elite.dog.core.library.model.statevalue.LevelStateValue;
 import it.polito.elite.dog.core.library.model.statevalue.OffStateValue;
 import it.polito.elite.dog.core.library.model.statevalue.OnStateValue;
+import it.polito.elite.dog.core.library.model.statevalue.StateValue;
 import it.polito.elite.dog.core.library.util.LogHelper;
 import it.polito.elite.dog.drivers.zwave.ZWaveAPI;
 import it.polito.elite.dog.drivers.zwave.model.zway.json.CommandClasses;
@@ -119,7 +120,7 @@ public class ZWavePowerMeteringLevelControllableOutputDriverInstance extends
 					+ SI.KILO(SI.WATT.times(NonSI.HOUR)).toString()));
 			this.currentState.setState(
 					SinglePhaseActiveEnergyState.class.getSimpleName(),
-					new SinglePhaseActiveEnergyState(energyStateValue));
+					new SinglePhaseActiveEnergyState(new StateValue[]{energyStateValue}));
 		}
 
 		// initialize the power state value
@@ -128,7 +129,7 @@ public class ZWavePowerMeteringLevelControllableOutputDriverInstance extends
 				+ SI.WATT.toString()));
 		this.currentState.setState(
 				SinglePhaseActivePowerMeasurementState.class.getSimpleName(),
-				new SinglePhaseActivePowerMeasurementState(powerStateValue));
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{powerStateValue}));
 
 		LevelStateValue levelValue = new LevelStateValue();
 		levelValue.setValue(DecimalMeasure.valueOf(0, Unit.ONE));
@@ -253,7 +254,7 @@ public class ZWavePowerMeteringLevelControllableOutputDriverInstance extends
 		pValue.setValue(value);
 		currentState.setState(
 				SinglePhaseActiveEnergyState.class.getSimpleName(),
-				new SinglePhaseActiveEnergyState(pValue));
+				new SinglePhaseActiveEnergyState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()
@@ -282,7 +283,7 @@ public class ZWavePowerMeteringLevelControllableOutputDriverInstance extends
 		pValue.setValue(powerValue);
 		currentState.setState(
 				SinglePhaseActivePowerMeasurementState.class.getSimpleName(),
-				new SinglePhaseActivePowerMeasurementState(pValue));
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()
@@ -623,7 +624,7 @@ public class ZWavePowerMeteringLevelControllableOutputDriverInstance extends
 		pValue.setValue(powerValue);
 		currentState.setState(
 				SinglePhaseActivePowerMeasurementState.class.getSimpleName(),
-				new SinglePhaseActivePowerMeasurementState(pValue));
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()
@@ -651,7 +652,7 @@ public class ZWavePowerMeteringLevelControllableOutputDriverInstance extends
 		pValue.setValue(value);
 		currentState.setState(
 				SinglePhaseActiveEnergyState.class.getSimpleName(),
-				new SinglePhaseActiveEnergyState(pValue));
+				new SinglePhaseActiveEnergyState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()

--- a/it.polito.elite.dog.drivers.zwave.singlephaseelectricitymeter/src/it/polito/elite/dog/drivers/zwave/singlephaseelectricitymeter/ZWaveSinglePhaseElectricityMeterInstance.java
+++ b/it.polito.elite.dog.drivers.zwave.singlephaseelectricitymeter/src/it/polito/elite/dog/drivers/zwave/singlephaseelectricitymeter/ZWaveSinglePhaseElectricityMeterInstance.java
@@ -27,6 +27,7 @@ import it.polito.elite.dog.core.library.model.state.SinglePhaseActiveEnergyState
 import it.polito.elite.dog.core.library.model.state.SinglePhaseActivePowerMeasurementState;
 import it.polito.elite.dog.core.library.model.statevalue.ActiveEnergyStateValue;
 import it.polito.elite.dog.core.library.model.statevalue.ActivePowerStateValue;
+import it.polito.elite.dog.core.library.model.statevalue.StateValue;
 import it.polito.elite.dog.core.library.util.LogHelper;
 import it.polito.elite.dog.drivers.zwave.ZWaveAPI;
 import it.polito.elite.dog.drivers.zwave.model.zway.json.CommandClasses;
@@ -91,11 +92,11 @@ public class ZWaveSinglePhaseElectricityMeterInstance extends
 		// initialize the state
 		this.currentState.setState(
 				SinglePhaseActiveEnergyState.class.getSimpleName(),
-				new SinglePhaseActiveEnergyState(new ActiveEnergyStateValue()));
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{new ActiveEnergyStateValue()}));
 		this.currentState.setState(SinglePhaseActivePowerMeasurementState.class
-				.getSimpleName(), new SinglePhaseActivePowerMeasurementState(
-				new ActivePowerStateValue()));
-
+				.getSimpleName(), 
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{new ActivePowerStateValue()}));
+				
 		// get the initial state of the device
 		Runnable worker = new Runnable()
 		{
@@ -206,7 +207,7 @@ public class ZWaveSinglePhaseElectricityMeterInstance extends
 		pValue.setValue(value);
 		currentState.setState(
 				SinglePhaseActiveEnergyState.class.getSimpleName(),
-				new SinglePhaseActiveEnergyState(pValue));
+				new SinglePhaseActiveEnergyState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()
@@ -235,7 +236,7 @@ public class ZWaveSinglePhaseElectricityMeterInstance extends
 		pValue.setValue(powerValue);
 		currentState.setState(
 				SinglePhaseActivePowerMeasurementState.class.getSimpleName(),
-				new SinglePhaseActivePowerMeasurementState(pValue));
+				new SinglePhaseActivePowerMeasurementState(new StateValue[]{pValue}));
 
 		// debug
 		logger.log(LogService.LOG_DEBUG, "Device " + device.getDeviceId()


### PR DESCRIPTION
Some of the states were initialised using the old deprecated format and this causes an exception at runtime. Updated to the new format.